### PR TITLE
Fix typos and such in `ceylon.language`.

### DIFF
--- a/src/ceylon/language/Character.ceylon
+++ b/src/ceylon/language/Character.ceylon
@@ -1,4 +1,4 @@
-doc "A 32-bit unicode character."
+doc "A 32-bit Unicode character."
 see (String)
 by "Gavin"
 shared abstract class Character()
@@ -46,10 +46,10 @@ shared abstract class Character()
     /*doc "The general category of the character"
     shared formal CharacterCategory category;*/
 
-    /*doc "The directionality of the character"
+    /*doc "The directionality of the character."
     shared formal CharacterDirectionality directionality;*/
     
-    doc "The code point of the character"
+    doc "The code point of the character."
     shared formal Integer integer;
 
 }

--- a/src/ceylon/language/Correspondence.ceylon
+++ b/src/ceylon/language/Correspondence.ceylon
@@ -1,7 +1,7 @@
 doc "Abstract supertype of objects which associate values 
      with keys. `Correspondence` does not satisfy `Category`,
      since in some cases, for examples lists, it is 
-     convenient to consider the subtype a `Category` of its
+     convenient to consider the subtype a `Container` of its
      values, and in other cases, for example maps, it is
      convenient to treat the subtype as a `Category` of its
      entries."

--- a/src/ceylon/language/Empty.ceylon
+++ b/src/ceylon/language/Empty.ceylon
@@ -14,36 +14,36 @@ shared interface Empty
         return emptyIterator;
     }
 
-    doc "Returns null for any given key."
+    doc "Returns `null` for any given key."
     shared actual Nothing item(Integer key) {
         return null;
     }
 
-    doc "Returns an Empty for any given segment."
+    doc "Returns an `Empty` for any given segment."
     shared actual Empty segment(Integer from, Integer length) {
         return this;
     }
 
-    doc "Returns an Empty for any given span."
+    doc "Returns an `Empty` for any given span."
     shared actual Empty span(Integer from, Integer? to) {
         return this;
     }
 
-    doc "Returns a string description of the empty List: `{}`"
+    doc "Returns a string description of the empty List: `{}`."
     shared actual String string {
         return "{}";
     }
-    doc "Returns null."
+    doc "Returns `null`."
     shared actual Nothing lastIndex { return null; }
 
     //shared actual Empty rest { return this; }
 
-    doc "Returns an Empty."
+    doc "Returns an `Empty`."
     shared actual Empty clone {
         return this;
     }
 
-    doc "Returns false for any given element."
+    doc "Returns `false` for any given element."
     shared actual Boolean contains(Object element) {
         return false;
     }

--- a/src/ceylon/language/Entry.ceylon
+++ b/src/ceylon/language/Entry.ceylon
@@ -1,4 +1,4 @@
-doc "A key, together with a value associated with the key,
+doc "A pair containing a key and an associated value
      called the item. Used primarily to represent the
      elements of a `Map`."
 by "Gavin"
@@ -13,7 +13,7 @@ shared class Entry<out Key, out Item>(key, item)
     doc "The value associated with the key."
     shared Item item;
 
-    doc "Determines if the this entry is equal to the given
+    doc "Determines if this entry is equal to the given
          entry. Two entries are equal if they have the same
          key and the same value."
     shared actual Boolean equals(Object that) {

--- a/src/ceylon/language/Exception.ceylon
+++ b/src/ceylon/language/Exception.ceylon
@@ -1,6 +1,6 @@
 doc "The supertype of all exceptions. A subclass represents
      a more specific kind of problem, and may define 
-     additional attributes which propogate information about
+     additional attributes which propagate information about
      problems of that kind."
 by "Gavin"
    "Tom"

--- a/src/ceylon/language/Float.ceylon
+++ b/src/ceylon/language/Float.ceylon
@@ -29,8 +29,8 @@ shared abstract class Float()
 
 }
 
-doc "The `Float` value of the given string representation of an decimal number
-     or `null` if the string does not represent an decimal number.
+doc "The `Float` value of the given string representation of a decimal number
+     or `null` if the string does not represent a decimal number.
      
      The syntax accepted by this method is the same as the syntax for a 
      `Float` literal in the Ceylon language except that it may optionally 

--- a/src/ceylon/language/Invertable.ceylon
+++ b/src/ceylon/language/Invertable.ceylon
@@ -1,15 +1,15 @@
-doc "Abstraction of types which support a unary inversion
+doc "Abstraction of types which support a unary additive inversion
      operation. For a numeric type, this should return the 
      negative of the argument value. Note that the type 
      parameter of this interface is not restricted to be a 
      self type, in order to accommodate the possibility of 
-     types whose inverse can only be expressed in terms of 
+     types whose additive inverse can only be expressed in terms of 
      a wider type."
 see (Integer, Float)
 by "Gavin"
 shared interface Invertable<out Inverse> {
     
-    doc "The inverse of the value, which may be expressed
+    doc "The additive inverse of the value, which may be expressed
          as an instance of a wider type."
     shared formal Inverse negativeValue;
     

--- a/src/ceylon/language/Iterator.ceylon
+++ b/src/ceylon/language/Iterator.ceylon
@@ -1,4 +1,4 @@
-doc "Produces elements if an `Iterable` object. Classes that 
+doc "Produces elements of an `Iterable` object. Classes that 
      implement this interface should be immutable."
 see (Iterable)
 by "Gavin"

--- a/src/ceylon/language/List.ceylon
+++ b/src/ceylon/language/List.ceylon
@@ -63,7 +63,7 @@ shared interface List<out Element>
          sequence."
     shared formal Sequence<Element> reversed;*/
 
-    /*doc "Select the elements between the given indexes. If 
+    /*doc "Select the elements between the given indices. If 
          the start index is the same as the end index,
          return a list with a single element. If the start 
          index is larger than the end index, return the

--- a/src/ceylon/language/Map.ceylon
+++ b/src/ceylon/language/Map.ceylon
@@ -12,7 +12,7 @@ shared interface Map<out Key,out Item>
         given Item satisfies Object {
 
     doc "Returns 1 if the argument is an entry and its
-         key and item match an entry in this map."
+         key and item match an entry in this `Map`."
     shared actual default Integer count(Object element) {
         if (is Key->Item element) {
             if (exists item = item(element.key)) {
@@ -27,7 +27,7 @@ shared interface Map<out Key,out Item>
         }
     }
 
-    doc "Two maps are considered equal if they have the same size,
+    doc "Two `Map`s are considered equal if they have the same size,
          the same set of keys, and equal elements stored under each key."
     shared actual default Boolean equals(Object that) {
         if (is Map<Object,Object> that) {
@@ -57,7 +57,7 @@ shared interface Map<out Key,out Item>
         return hashCode;
     }
 
-    doc "Returns the set of keys contained in this map."
+    doc "Returns the set of keys contained in this `Map`."
     actual shared default Set<Key> keys {
         object keySet satisfies Set<Key> {
             shared actual Set<Key> clone {
@@ -98,8 +98,8 @@ shared interface Map<out Key,out Item>
         return keySet;
     }
 
-    doc "Returns all the values stored in this map. An element
-         can be stored under more than one key in the map, and so
+    doc "Returns all the values stored in this `Map`. An element
+         can be stored under more than one key in the `Map`, and so
          it can be contained more than once in the resulting collection."
     shared default Collection<Item> values {
         object valueCollection satisfies Collection<Item> {
@@ -126,8 +126,8 @@ shared interface Map<out Key,out Item>
         return valueCollection;
     }
 
-    doc "Returns a map in which every key is an Item in this map,
-         and every value is the set of keys that stored the Item
+    doc "Returns a map in which every key is an `Item` in this map,
+         and every value is the set of keys that stored the `Item`
          in this map."
     shared default Map<Item, Set<Key>> inverse {
         object inverse satisfies Map<Item, Set<Key>> {

--- a/src/ceylon/language/None.ceylon
+++ b/src/ceylon/language/None.ceylon
@@ -14,7 +14,7 @@ shared interface None<out Element>
         return null;
     }
 
-    doc "Returns an emptyIterator."
+    doc "Returns `emptyIterator`."
     shared actual default Iterator<Element> iterator {
         return emptyIterator;
     }

--- a/src/ceylon/language/Ranged.ceylon
+++ b/src/ceylon/language/Ranged.ceylon
@@ -5,7 +5,7 @@ shared interface Ranged<in Index, out Span>
         given Index satisfies Comparable<Index> {
     
     doc "Obtain a span containing the mapped values between 
-         the two given indexes. If the second given index
+         the two given indices. If the second given index
          is null, the span has no upper bound."
     shared formal Span span(Index from, Index? to);
     

--- a/src/ceylon/language/SequenceBuilder.ceylon
+++ b/src/ceylon/language/SequenceBuilder.ceylon
@@ -32,7 +32,7 @@ shared class SequenceBuilder<Element>() satisfies Sized {
 doc "This class is used for constructing a new nonempty 
      sequence by incrementally appending elements to an
      existing nonempty sequence. The existing sequence is
-     not modified, since sequences are immutable. This class 
+     not modified, since `Sequence`s are immutable. This class 
      is mutable but threadsafe."
 see (SequenceBuilder)
 shared class SequenceAppender<Element>(Sequence<Element> elements) 

--- a/src/ceylon/language/Set.ceylon
+++ b/src/ceylon/language/Set.ceylon
@@ -6,14 +6,14 @@ shared interface Set<out Element>
                   Cloneable<Set<Element>>
         given Element satisfies Object {
 
-    doc "Returns 1 if the element is part of this Set, 0 otherwise."
+    doc "Returns 1 if the element is part of this `Set`, or 0 otherwise."
     shared actual default Integer count(Object element) {
         return contains(element) then 1 else 0;
     }
 
-    doc "Determines if this Set is a superset of the specified Set,
-         that is, if this Set contains all of the elements in the
-         specified Set."
+    doc "Determines if this `Set` is a superset of the specified Set,
+         that is, if this `Set` contains all of the elements in the
+         specified `Set`."
     shared default Boolean superset(Set<Object> set) {
         for (element in set) {
             if (!contains(element)) {
@@ -25,9 +25,9 @@ shared interface Set<out Element>
         }
     }
 
-    doc "Determines if this Set is a subset of the specified Set,
+    doc "Determines if this `Set` is a subset of the specified `Set`,
          that is, if the specified Set contains all of the
-         elements in this Set."
+         elements in this `Set`."
     shared default Boolean subset(Set<Object> set) {
         for (element in this) {
             if (!set.contains(element)) {
@@ -39,8 +39,8 @@ shared interface Set<out Element>
         }
     }
 
-    doc "Two Sets are considered equal if they have the same size
-         and all its elements are equal."
+    doc "Two `Set`s are considered equal if they have the same size
+         and share all the same elements."
     shared actual default Boolean equals(Object that) {
         if (is Set<Object> that) {
             if (that.size==size) {
@@ -66,23 +66,23 @@ shared interface Set<out Element>
         return hashCode;
     }
 
-    doc "Returns a new Set containing all the elements of this Set
-         and all the elements of the specified Set."
+    doc "Returns a new `Set` containing all the elements of this `Set`
+         and all the elements of the specified `Set`."
     shared formal Set<Element|Other> union<Other>(Set<Other> set)
             given Other satisfies Object;
 
-    doc "Returns a new Set containing only the elements contained
-         both in this Set and the specified Set."
+    doc "Returns a new `Set` containing only the elements that are present in
+         both this `Set` and the specified `Set`."
     shared formal Set<Element&Other> intersection<Other>(Set<Other> set)
             given Other satisfies Object;
 
-    doc "Returns a new Set containing only the elements contained in
-         this Set or the specified Set, but not both."
+    doc "Returns a new `Set` containing only the elements contained in either
+         this `Set` or the specified `Set`, but not both."
     shared formal Set<Element|Other> exclusiveUnion<Other>(Set<Other> set)
             given Other satisfies Object;
 
-    doc "Returns a new set containing all the elements in the specified Set
-         that are not contained in this Set."
+    doc "Returns a new set containing all the elements in the specified `Set`
+         that are not contained in this `Set`."
     shared formal Set<Element> complement<Other>(Set<Other> set)
             given Other satisfies Object;
 

--- a/src/ceylon/language/Singleton.ceylon
+++ b/src/ceylon/language/Singleton.ceylon
@@ -12,19 +12,19 @@ shared class Singleton<Element>(Element element)
     shared actual Integer size {
         return 1;
     }
-    doc "Returns the element contained in this Sequence."
+    doc "Returns the element contained in this `Singleton`."
     shared actual Element first {
         return element;
     }
-    doc "Returns the element contained in this Sequence."
+    doc "Returns the element contained in this `Singleton`."
     shared actual Element last {
         return element;
     }
-    doc "Returns Empty."
+    doc "Returns `Empty`."
     shared actual Empty rest {
         return {};
     }
-    doc "Returns the contained element, if the index is 0."
+    doc "Returns the contained element, if the specified index is 0."
     shared actual Element? item(Integer index) {
         if (index==0) {
             return element;
@@ -33,7 +33,7 @@ shared class Singleton<Element>(Element element)
             return null;
         }
     }
-    doc "Returns a Singleton with the same element."
+    doc "Returns a `Singleton` with the same element."
     shared actual Singleton<Element> clone {
         return this;
     }
@@ -58,18 +58,18 @@ shared class Singleton<Element>(Element element)
         return "{ " first.string " }";
     }
 
-    doc "Returns a Singleton if the starting position is 0 and the length is greater than 0."
+    doc "Returns a `Singleton` if the starting position is 0 and the length is greater than 0."
     shared actual Element[] segment(Integer from, Integer length) {
         return from>0 || length==0 then {} else this;
     }
 
-    doc "Returns a Singleton if the starting position is 0."
+    doc "Returns a `Singleton` if the starting position is 0."
     shared actual Element[] span(Integer from, Integer? to) {
         return from>0 then {} else this;
     }
 
-    doc "A Singleton can be equal to another List if that List has only one element which is
-         equal to this Singleton's element."
+    doc "A `Singleton` can be equal to another `List` if that `List` has only one element which is
+         equal to this `Singleton`'s element."
     shared actual Boolean equals(Object that) {
         if (is List<Element> that) {
             if (that.size!=1) {
@@ -91,12 +91,12 @@ shared class Singleton<Element>(Element element)
         return 1;
     }
 
-    doc "Returns true if the specified element is this Singleton's element."
+    doc "Returns `true` if the specified element is this `Singleton`'s element."
     shared actual Boolean contains(Object element) {
         return this.element==element;
     }
 
-    doc "Returns 1 if the specified element is this Singleton's element, 0 otherwise."
+    doc "Returns 1 if the specified element is this `Singleton`'s element, or 0 otherwise."
     shared actual Integer count(Object element) {
         return contains(element) then 1 else 0;
     }

--- a/src/ceylon/language/String.ceylon
+++ b/src/ceylon/language/String.ceylon
@@ -1,5 +1,5 @@
 doc "A string of characters. Each character in the string is 
-     a 32-bit unicode character. The internal UTF-16 
+     a 32-bit Unicode character. The internal UTF-16 
      encoding is hidden from clients."
 by "Gavin"
 shared abstract class String()
@@ -21,11 +21,11 @@ shared abstract class String()
     
     doc "Split the string into tokens, using the given
          separator characters. If no separator characters
-         are given, split the string at any unicode 
+         are given, split the string at any Unicode 
          whitespace character."
     shared formal Iterable<String> split(
             doc "The separator characters at which to split.
-                 If `null`, split at any unicode whitespace
+                 If `null`, split at any Unicode whitespace
                  character."
             Iterable<Character>? separators=null,
             doc "Specifies that the separator characters
@@ -56,7 +56,7 @@ shared abstract class String()
     doc "Select the characters between the given indexes.
          If the start index is the same as the end index,
          return a string with a single character.
-         If the start index larger than the end index, 
+         If the start index is larger than the end index, 
          return the characters in the reverse order from
          the order in which they appear in this string.
          If both the start index and the end index are 
@@ -69,8 +69,10 @@ shared abstract class String()
     
     doc "Select the characters of this string beginning at 
          the given index, returning a string no longer than 
-         the given length. If this string is shorter than 
-         the given length, return this string. Otherwise 
+         the given length. If the portion of this string
+         starting at the given index is shorter than 
+         the given length, return the portion of this string
+         from the given index until the end of this string. Otherwise 
          return a string of the given length. If the start
          index is larger than the last index of the string,
          return the empty string."
@@ -149,7 +151,7 @@ shared abstract class String()
          not occur in this string."
     shared formal Integer? lastCharacterOccurrence(Character substring);
     
-        doc "Determines if the given object is a `String` and, 
+    doc "Determines if the given object is a `String` and, 
          if so, if it occurs as a substring of this string,
          or if the object is a `Character` that occurs in
          this string. That is to say, a string is considered 

--- a/src/ceylon/language/descriptor/descriptor.ceylon
+++ b/src/ceylon/language/descriptor/descriptor.ceylon
@@ -13,7 +13,7 @@ shared class Package(
         String doc="",
 
         desc "The names of the authors of the
-             package"
+             package."
         String[] by = {}) {
 
     //TODO implement
@@ -56,7 +56,7 @@ shared class Module(
         String doc = "",
         
         desc "The names of the authors of the
-             module"
+             module."
         String[] by = {},
 
         desc "The license under which the module

--- a/src/ceylon/language/metamodel/Annotated.ceylon
+++ b/src/ceylon/language/metamodel/Annotated.ceylon
@@ -1,3 +1,3 @@
-doc "An program element that can
+doc "A program element that can
      be annotated."
 shared interface Annotated {}

--- a/src/ceylon/language/zip.ceylon
+++ b/src/ceylon/language/zip.ceylon
@@ -2,7 +2,7 @@ doc "Given two sequences, form a new sequence consisting of
      all entries where, for any given index in the resulting
      sequence, the key of the entry is the element occurring 
      at the same index in the first sequence, and the item 
-     is the element ocurring at the same index in the second 
+     is the element occurring at the same index in the second 
      sequence. The length of the resulting sequence is the 
      length of the shorter of the two given sequences. 
      
@@ -10,7 +10,7 @@ doc "Given two sequences, form a new sequence consisting of
      
          zip(xs,ys)[i]==xs[i]->ys[i]
      
-     for every `0<=i<min({xs.size,ys.zize})`."
+     for every `0<=i<min({xs.size,ys.size})`."
 shared Entry<Key,Item>[] zip<Key,Item>(Iterable<Key> keys, Iterable<Item> items)
         given Key satisfies Object
         given Item satisfies Object {


### PR DESCRIPTION
This comprises documentation tweaks including:
- Capitalize 'Unicode' where it was lowercase.
- More backticks.
- Misc typos, grammar.
- A few phrasing tweaks.
- Normalize inconsistent use of terms "indexes" and "indices" to just "indices".
