### PR TITLE
make sum(), min(), max() tolerate unstable first/rest

### DIFF
--- a/src/ceylon/language/max.ceylon
+++ b/src/ceylon/language/max.ceylon
@@ -6,10 +6,10 @@ see (`interface Comparable`,
 shared Absent|Value max<Value,Absent>(Iterable<Value,Absent> values) 
         given Value satisfies Comparable<Value>
         given Absent satisfies Null {
-    value first=values.first;
-    if (exists first) {
+    value it = values.iterator();
+    if (is Value first = it.next()) {
         variable value max=first;
-        for (val in values.rest) {
+        while (is Value val = it.next()) {
             if (val>max) {
                 max=val;
             }
@@ -17,6 +17,8 @@ shared Absent|Value max<Value,Absent>(Iterable<Value,Absent> values)
         return max;
     }
     else {
-        return first;
+        "iterable must be empty"
+        assert (is Absent null);
+        return null;
     }
 }

--- a/src/ceylon/language/min.ceylon
+++ b/src/ceylon/language/min.ceylon
@@ -6,10 +6,10 @@ see (`interface Comparable`,
 shared Absent|Value min<Value,Absent>(Iterable<Value,Absent> values) 
         given Value satisfies Comparable<Value>
         given Absent satisfies Null {
-    value first=values.first;
-    if (exists first) {
+    value it = values.iterator();
+    if (is Value first = it.next()) {
         variable value min=first;
-        for (val in values.rest) {
+        while (is Value val = it.next()) {
             if (val<min) {
                 min=val;
             }
@@ -17,6 +17,8 @@ shared Absent|Value min<Value,Absent>(Iterable<Value,Absent> values)
         return min;
     }
     else {
-        return first;
+        "iterable must be empty"
+        assert (is Absent null);
+        return null;
     }
 }

--- a/src/ceylon/language/sum.ceylon
+++ b/src/ceylon/language/sum.ceylon
@@ -3,8 +3,10 @@
 see (`function product`)
 shared Value sum<Value>({Value+} values) 
         given Value satisfies Summable<Value> {
-    variable value sum = values.first;
-    for (val in values.rest) {
+    value it = values.iterator();
+    assert (is Value first = it.next());
+    variable value sum = first;
+    while (is Value val = it.next()) {
         sum+=val;
     }
     return sum;


### PR DESCRIPTION
An humble contribution based on a what was recently done for `reduce()`, but this time for sum(), min() and max().
If this modification was not desirable please just ignore this pull request
