### PR TITLE
Util: various improvements to toXArray functions

### DIFF
--- a/runtime/com/redhat/ceylon/compiler/java/Util.java
+++ b/runtime/com/redhat/ceylon/compiler/java/Util.java
@@ -211,33 +211,33 @@ public class Util {
     @SuppressWarnings("unchecked")
     public static boolean[] 
     toBooleanArray(ceylon.language.Iterable<? extends ceylon.language.Boolean, ?> sequence,
-    		boolean... initialElements){
+            boolean... initialElements){
         if(sequence instanceof ceylon.language.List)
-            return toBooleanArray((ceylon.language.List<? extends ceylon.language.Boolean>)sequence, 
-            		initialElements);
+            return toBooleanArray((ceylon.language.List<? extends ceylon.language.Boolean>)sequence,
+                    initialElements);
         List<ceylon.language.Boolean> list = collectIterable(sequence);
-        boolean[] ret = new boolean[list.size() + initialElements.length];
-        int i=0;
-        for(;i<initialElements.length;i++){
-            ret[i] = initialElements[i];
-        }
+        int i=initialElements.length;
+        boolean[] ret = new boolean[list.size() + i];
+        System.arraycopy(initialElements, 0, ret, 0, i);
         for(ceylon.language.Boolean e : list){
             ret[i++] = e.booleanValue();
         }
         return ret;
     }
-    
-    public static boolean[] 
-    toBooleanArray(ceylon.language.List<? extends ceylon.language.Boolean> sequence,
-    		boolean... initialElements){
-        boolean[] ret = new boolean[(int) sequence.getSize() + initialElements.length];
-        int i=0;
-        for(;i<initialElements.length;i++){
-            ret[i] = initialElements[i];
-        }
-        while(!sequence.getEmpty()){
-            ret[i++] = sequence.getFirst().booleanValue();
-            sequence = (ceylon.language.List<? extends ceylon.language.Boolean>)sequence.getRest();
+
+    @SuppressWarnings("unchecked")
+    public static boolean[]
+    toBooleanArray(ceylon.language.List<? extends ceylon.language.Boolean> list,
+            boolean... initialElements){
+        if(list == null)
+            return initialElements;
+        int i=initialElements.length;
+        boolean[] ret = new boolean[(int) list.getSize() + i];
+        System.arraycopy(initialElements, 0, ret, 0, i);
+        Iterator<? extends ceylon.language.Boolean> iterator = list.iterator();
+        Object o;
+        while((o = iterator.next()) != finished_.get_()){
+            ret[i++] = ((ceylon.language.Boolean)o).booleanValue();
         }
         return ret;
     }
@@ -245,12 +245,12 @@ public class Util {
     @SuppressWarnings("unchecked")
     public static byte[] 
     toByteArray(ceylon.language.Iterable<? extends ceylon.language.Integer, ?> sequence,
-    		long... initialElements){
+            long... initialElements){
         if(sequence instanceof ceylon.language.List)
-            return toByteArray((ceylon.language.List<? extends ceylon.language.Integer>)sequence, 
-            		initialElements);
+            return toByteArray((ceylon.language.List<? extends ceylon.language.Integer>)sequence,
+                    initialElements);
         List<ceylon.language.Integer> list = collectIterable(sequence);
-        byte[] ret = new byte[initialElements.length + list.size()];
+        byte[] ret = new byte[list.size() + initialElements.length];
         int i=0;
         for(;i<initialElements.length;i++){
             ret[i] = (byte) initialElements[i];
@@ -261,17 +261,21 @@ public class Util {
         return ret;
     }
 
-    public static byte[] 
-    toByteArray(ceylon.language.List<? extends ceylon.language.Integer> sequence,
-    		long... initialElements){
-        byte[] ret = new byte[initialElements.length + (int) sequence.getSize()];
+    @SuppressWarnings("unchecked")
+    public static byte[]
+    toByteArray(ceylon.language.List<? extends ceylon.language.Integer> list,
+            long... initialElements){
+        byte[] ret = new byte[(list == null ? 0 : (int) list.getSize()) + initialElements.length];
         int i=0;
         for(;i<initialElements.length;i++){
             ret[i] = (byte) initialElements[i];
         }
-        while(!sequence.getEmpty()){
-            ret[i++] = (byte) sequence.getFirst().longValue();
-            sequence = (ceylon.language.List<? extends ceylon.language.Integer>)sequence.getRest();
+        if(list != null){
+            Iterator<? extends ceylon.language.Integer> iterator = list.iterator();
+            Object o;
+            while((o = iterator.next()) != finished_.get_()){
+                ret[i++] = (byte)((ceylon.language.Integer)o).longValue();
+            }
         }
         return ret;
     }
@@ -279,10 +283,10 @@ public class Util {
     @SuppressWarnings("unchecked")
     public static short[] 
     toShortArray(ceylon.language.Iterable<? extends ceylon.language.Integer, ?> sequence,
-    		long... initialElements){
+            long... initialElements){
         if(sequence instanceof ceylon.language.List)
-            return toShortArray((ceylon.language.List<? extends ceylon.language.Integer>)sequence, 
-            		initialElements);
+            return toShortArray((ceylon.language.List<? extends ceylon.language.Integer>)sequence,
+                    initialElements);
         List<ceylon.language.Integer> list = collectIterable(sequence);
         short[] ret = new short[list.size() + initialElements.length];
         int i=0;
@@ -295,17 +299,21 @@ public class Util {
         return ret;
     }
 
-    public static short[] 
-    toShortArray(ceylon.language.List<? extends ceylon.language.Integer> sequence,
-    		long... initialElements){
-        short[] ret = new short[(int) sequence.getSize() + initialElements.length];
+    @SuppressWarnings("unchecked")
+    public static short[]
+    toShortArray(ceylon.language.List<? extends ceylon.language.Integer> list,
+            long... initialElements){
+        short[] ret = new short[(list == null ? 0 : (int) list.getSize()) + initialElements.length];
         int i=0;
         for(;i<initialElements.length;i++){
             ret[i] = (short) initialElements[i];
         }
-        while(!sequence.getEmpty()){
-            ret[i++] = (short) sequence.getFirst().longValue();
-            sequence = (ceylon.language.List<? extends ceylon.language.Integer>)sequence.getRest();
+        if(list != null){
+            Iterator<? extends ceylon.language.Integer> iterator = list.iterator();
+            Object o;
+            while((o = iterator.next()) != finished_.get_()){
+                ret[i++] = (short)((ceylon.language.Integer)o).longValue();
+            }
         }
         return ret;
     }
@@ -313,10 +321,10 @@ public class Util {
     @SuppressWarnings("unchecked")
     public static int[] 
     toIntArray(ceylon.language.Iterable<? extends ceylon.language.Integer, ?> sequence,
-    		long... initialElements){
+            long... initialElements){
         if(sequence instanceof ceylon.language.List)
-            return toIntArray((ceylon.language.List<? extends ceylon.language.Integer>)sequence, 
-            		initialElements);
+            return toIntArray((ceylon.language.List<? extends ceylon.language.Integer>)sequence,
+                    initialElements);
         List<ceylon.language.Integer> list = collectIterable(sequence);
         int[] ret = new int[list.size() + initialElements.length];
         int i=0;
@@ -329,17 +337,21 @@ public class Util {
         return ret;
     }
 
-    public static int[] 
-    toIntArray(ceylon.language.List<? extends ceylon.language.Integer> sequence,
-    		long... initialElements){
-        int[] ret = new int[(int) sequence.getSize() + initialElements.length];
+    @SuppressWarnings("unchecked")
+    public static int[]
+    toIntArray(ceylon.language.List<? extends ceylon.language.Integer> list,
+            long... initialElements){
+        int[] ret = new int[(list == null ? 0 : (int) list.getSize()) + initialElements.length];
         int i=0;
         for(;i<initialElements.length;i++){
             ret[i] = (int) initialElements[i];
         }
-        while(!sequence.getEmpty()){
-            ret[i++] = (int) sequence.getFirst().longValue();
-            sequence = (ceylon.language.List<? extends ceylon.language.Integer>)sequence.getRest();
+        if(list != null){
+            Iterator<? extends ceylon.language.Integer> iterator = list.iterator();
+            Object o;
+            while((o = iterator.next()) != finished_.get_()){
+                ret[i++] = (int)((ceylon.language.Integer)o).longValue();
+            }
         }
         return ret;
     }
@@ -347,33 +359,33 @@ public class Util {
     @SuppressWarnings("unchecked")
     public static long[] 
     toLongArray(ceylon.language.Iterable<? extends ceylon.language.Integer, ?> sequence,
-    		long... initialElements){
+            long... initialElements){
         if(sequence instanceof ceylon.language.List)
-            return toLongArray((ceylon.language.List<? extends ceylon.language.Integer>)sequence, 
-            		initialElements);
+            return toLongArray((ceylon.language.List<? extends ceylon.language.Integer>)sequence,
+                    initialElements);
         List<ceylon.language.Integer> list = collectIterable(sequence);
-        long[] ret = new long[list.size() + initialElements.length];
-        int i=0;
-        for(;i<initialElements.length;i++){
-            ret[i] = initialElements[i];
-        }
+        int i=initialElements.length;
+        long[] ret = new long[list.size() + i];
+        System.arraycopy(initialElements, 0, ret, 0, i);
         for(ceylon.language.Integer e : list){
             ret[i++] = e.longValue();
         }
         return ret;
     }
 
-    public static long[] 
-    toLongArray(ceylon.language.List<? extends ceylon.language.Integer> sequence,
-    		long... initialElements){
-        long[] ret = new long[(int) sequence.getSize() + initialElements.length];
-        int i=0;
-        for(;i<initialElements.length;i++){
-            ret[i] = initialElements[i];
-        }
-        while(!sequence.getEmpty()){
-            ret[i++] = sequence.getFirst().longValue();
-            sequence = (ceylon.language.List<? extends ceylon.language.Integer>)sequence.getRest();
+    @SuppressWarnings("unchecked")
+    public static long[]
+    toLongArray(ceylon.language.List<? extends ceylon.language.Integer> list,
+            long... initialElements){
+        if(list == null)
+            return initialElements;
+        int i=initialElements.length;
+        long[] ret = new long[(int) list.getSize() + i];
+        System.arraycopy(initialElements, 0, ret, 0, i);
+        Iterator<? extends ceylon.language.Integer> iterator = list.iterator();
+        Object o;
+        while((o = iterator.next()) != finished_.get_()){
+            ret[i++] = ((ceylon.language.Integer)o).longValue();
         }
         return ret;
     }
@@ -381,12 +393,12 @@ public class Util {
     @SuppressWarnings("unchecked")
     public static float[] 
     toFloatArray(ceylon.language.Iterable<? extends ceylon.language.Float, ?> sequence, 
-    		double... initialElements){
+            double... initialElements){
         if(sequence instanceof ceylon.language.List)
-            return toFloatArray((ceylon.language.List<? extends ceylon.language.Float>)sequence, 
-            		initialElements);
+            return toFloatArray((ceylon.language.List<? extends ceylon.language.Float>)sequence,
+                    initialElements);
         List<ceylon.language.Float> list = collectIterable(sequence);
-        float[] ret = new float[initialElements.length + list.size()];
+        float[] ret = new float[list.size() + initialElements.length];
         int i=0;
         for(;i<initialElements.length;i++){
             ret[i] = (float) initialElements[i];
@@ -397,17 +409,21 @@ public class Util {
         return ret;
     }
 
-    public static float[] 
-    toFloatArray(ceylon.language.List<? extends ceylon.language.Float> sequence,
-    		double... initialElements){
-        float[] ret = new float[initialElements.length + (int) sequence.getSize()];
-        int i = 0;
+    @SuppressWarnings("unchecked")
+    public static float[]
+    toFloatArray(ceylon.language.List<? extends ceylon.language.Float> list,
+            double... initialElements){
+        float[] ret = new float[(list == null ? 0 : (int) list.getSize()) + initialElements.length];
+        int i=0;
         for(;i<initialElements.length;i++){
             ret[i] = (float) initialElements[i];
         }
-        while(!sequence.getEmpty()){
-            ret[i++] = (float) sequence.getFirst().doubleValue();
-            sequence = (ceylon.language.List<? extends ceylon.language.Float>)sequence.getRest();
+        if(list != null){
+            Iterator<? extends ceylon.language.Float> iterator = list.iterator();
+            Object o;
+            while((o = iterator.next()) != finished_.get_()){
+                ret[i++] = (float)((ceylon.language.Float)o).doubleValue();
+            }
         }
         return ret;
     }
@@ -415,33 +431,33 @@ public class Util {
     @SuppressWarnings("unchecked")
     public static double[] 
     toDoubleArray(ceylon.language.Iterable<? extends ceylon.language.Float, ?> sequence,
-    		double... initialElements){
+            double... initialElements){
         if(sequence instanceof ceylon.language.List)
-            return toDoubleArray((ceylon.language.List<? extends ceylon.language.Float>)sequence, 
-            		initialElements);
+            return toDoubleArray((ceylon.language.List<? extends ceylon.language.Float>)sequence,
+                    initialElements);
         List<ceylon.language.Float> list = collectIterable(sequence);
-        double[] ret = new double[list.size() + initialElements.length];
-        int i=0;
-        for(;i<initialElements.length;i++){
-            ret[i] = initialElements[i];
-        }
+        int i=initialElements.length;
+        double[] ret = new double[list.size() + i];
+        System.arraycopy(initialElements, 0, ret, 0, i);
         for(ceylon.language.Float e : list){
             ret[i++] = e.doubleValue();
         }
         return ret;
     }
 
-    public static double[] 
-    toDoubleArray(ceylon.language.List<? extends ceylon.language.Float> sequence,
-    		double... initialElements){
-        double[] ret = new double[(int) sequence.getSize() + initialElements.length];
-        int i=0;
-        for(;i<initialElements.length;i++){
-            ret[i] = initialElements[i];
-        }
-        while(!sequence.getEmpty()){
-            ret[i++] = sequence.getFirst().doubleValue();
-            sequence = (ceylon.language.List<? extends ceylon.language.Float>)sequence.getRest();
+    @SuppressWarnings("unchecked")
+    public static double[]
+    toDoubleArray(ceylon.language.List<? extends ceylon.language.Float> list,
+            double... initialElements){
+        if(list == null)
+            return initialElements;
+        int i=initialElements.length;
+        double[] ret = new double[(int) list.getSize() + i];
+        System.arraycopy(initialElements, 0, ret, 0, i);
+        Iterator<? extends ceylon.language.Float> iterator = list.iterator();
+        Object o;
+        while((o = iterator.next()) != finished_.get_()){
+            ret[i++] = ((ceylon.language.Float)o).doubleValue();
         }
         return ret;
     }
@@ -449,10 +465,10 @@ public class Util {
     @SuppressWarnings("unchecked")
     public static char[] 
 	toCharArray(ceylon.language.Iterable<? extends ceylon.language.Character, ?> sequence,
-			int... initialElements){
+	        int... initialElements){
         if(sequence instanceof ceylon.language.List)
             return toCharArray((ceylon.language.List<? extends ceylon.language.Character>)sequence, 
-            		initialElements);
+                    initialElements);
         List<ceylon.language.Character> list = collectIterable(sequence);
         char[] ret = new char[list.size() + initialElements.length];
         int i=0;
@@ -468,14 +484,14 @@ public class Util {
 
     public static char[] 
 	toCharArray(ceylon.language.List<? extends ceylon.language.Character> sequence,
-			int... initialElements){
-        char[] ret = new char[(int) sequence.getSize() + initialElements.length];
+	        int... initialElements){
+        char[] ret = new char[(sequence == null ? 0 : (int) sequence.getSize()) + initialElements.length];
         int i=0;
         // FIXME: this is invalid and should yield a larger array by splitting chars > 16 bits in two
         for(;i<initialElements.length;i++){
             ret[i] = (char) initialElements[i];
         }
-        while(!sequence.getEmpty()){
+        while(sequence != null && !sequence.getEmpty()){
             ret[i++] = (char) sequence.getFirst().intValue();
             sequence = (ceylon.language.List<? extends ceylon.language.Character>)sequence.getRest();
         }
@@ -485,33 +501,33 @@ public class Util {
     @SuppressWarnings("unchecked")
     public static int[] 
 	toCodepointArray(ceylon.language.Iterable<? extends ceylon.language.Character, ?> sequence,
-			int... initialElements){
+	        int... initialElements){
         if(sequence instanceof ceylon.language.List)
-            return toCodepointArray((ceylon.language.List<? extends ceylon.language.Character>)sequence, 
-            		initialElements);
+            return toCodepointArray((ceylon.language.List<? extends ceylon.language.Character>)sequence,
+                    initialElements);
         List<ceylon.language.Character> list = collectIterable(sequence);
-        int[] ret = new int[list.size() + initialElements.length];
-        int i=0;
-        for(;i<initialElements.length;i++){
-            ret[i] = initialElements[i];
-        }
+        int i=initialElements.length;
+        int[] ret = new int[list.size() + i];
+        System.arraycopy(initialElements, 0, ret, 0, i);
         for(ceylon.language.Character e : list){
             ret[i++] = e.intValue();
         }
         return ret;
     }
 
-    public static int[] 
-    toCodepointArray(ceylon.language.List<? extends ceylon.language.Character> sequence,
+    @SuppressWarnings("unchecked")
+    public static int[]
+    toCodepointArray(ceylon.language.List<? extends ceylon.language.Character> list,
             int... initialElements){
-        int[] ret = new int[(int) sequence.getSize() + initialElements.length];
-        int i=0;
-        for(;i<initialElements.length;i++){
-            ret[i] = initialElements[i];
-        }
-        while(!sequence.getEmpty()){
-            ret[i++] = sequence.getFirst().intValue();
-            sequence = (ceylon.language.List<? extends ceylon.language.Character>)sequence.getRest();
+        if(list == null)
+            return initialElements;
+        int i=initialElements.length;
+        int[] ret = new int[(int) list.getSize() + i];
+        System.arraycopy(initialElements, 0, ret, 0, i);
+        Iterator<? extends ceylon.language.Character> iterator = list.iterator();
+        Object o;
+        while((o = iterator.next()) != finished_.get_()){
+            ret[i++] = ((ceylon.language.Character)o).intValue();
         }
         return ret;
     }
@@ -521,31 +537,31 @@ public class Util {
     toJavaStringArray(ceylon.language.Iterable<? extends ceylon.language.String, ?> sequence,
             java.lang.String... initialElements){
         if(sequence instanceof ceylon.language.List)
-            return toJavaStringArray((ceylon.language.List<? extends ceylon.language.String>)sequence, 
-            		initialElements);
+            return toJavaStringArray((ceylon.language.List<? extends ceylon.language.String>)sequence,
+                    initialElements);
         List<ceylon.language.String> list = collectIterable(sequence);
-        java.lang.String[] ret = new java.lang.String[list.size() + initialElements.length];
-        int i=0;
-        for(;i<initialElements.length;i++){
-            ret[i] = initialElements[i];
-        }
+        int i=initialElements.length;
+        java.lang.String[] ret = new java.lang.String[list.size() + i];
+        System.arraycopy(initialElements, 0, ret, 0, i);
         for(ceylon.language.String e : list){
             ret[i++] = e.toString();
         }
         return ret;
     }
 
-    public static java.lang.String[] 
-    toJavaStringArray(ceylon.language.List<? extends ceylon.language.String> sequence,
+    @SuppressWarnings("unchecked")
+    public static java.lang.String[]
+    toJavaStringArray(ceylon.language.List<? extends ceylon.language.String> list,
             java.lang.String... initialElements){
-        java.lang.String[] ret = new java.lang.String[(int) sequence.getSize() + initialElements.length];
-        int i=0;
-        for(;i<initialElements.length;i++){
-            ret[i] = initialElements[i];
-        }
-        while(!sequence.getEmpty()){
-            ret[i++] = sequence.getFirst().toString();
-            sequence = (ceylon.language.List<? extends ceylon.language.String>)sequence.getRest();
+        if(list == null)
+            return initialElements;
+        int i=initialElements.length;
+        java.lang.String[] ret = new java.lang.String[(int) list.getSize() + i];
+        System.arraycopy(initialElements, 0, ret, 0, i);
+        Iterator<? extends ceylon.language.String> iterator = list.iterator();
+        Object o;
+        while((o = iterator.next()) != finished_.get_()){
+            ret[i++] = ((ceylon.language.String)o).toString();
         }
         return ret;
     }
@@ -553,26 +569,14 @@ public class Util {
     @SuppressWarnings("unchecked")
     public static <T> T[] toArray(ceylon.language.List<? extends T> sequence,
             T[] ret, T... initialElements){
-        System.arraycopy(initialElements, 0, ret, 0, initialElements.length);
+        if(sequence == null)
+            return initialElements;
         int i=initialElements.length;
-        while(!sequence.getEmpty()){
-            ret[i++] = sequence.getFirst();
-            sequence = (ceylon.language.List<? extends T>)sequence.getRest();
-        }
-        return ret;
-    }
-
-    @SuppressWarnings("unchecked")
-    public static <T> T[] toArray(ceylon.language.List<? extends T> sequence,
-            java.lang.Class<T> klass, T... initialElements){
-        T[] ret = (T[]) java.lang.reflect.Array.newInstance(klass, 
-        		(int)sequence.getSize() + initialElements.length);
-
-        System.arraycopy(initialElements, 0, ret, 0, initialElements.length);
-        int i=initialElements.length;
-        while(!sequence.getEmpty()){
-            ret[i++] = sequence.getFirst();
-            sequence = (ceylon.language.List<? extends T>)sequence.getRest();
+        System.arraycopy(initialElements, 0, ret, 0, i);
+        Iterator<? extends T> iterator = sequence.iterator();
+        Object o;
+        while((o = iterator.next()) != finished_.get_()){
+            ret[i++] = (T)o;
         }
         return ret;
     }
@@ -594,6 +598,23 @@ public class Util {
             int i = initialElements.length;
             for(T o : list)
                 ret[i++] = o;
+        }
+        return ret;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T[] toArray(ceylon.language.List<? extends T> list,
+            java.lang.Class<T> klass, T... initialElements){
+        if(list == null)
+            return initialElements;
+        int i=initialElements.length;
+        T[] ret = (T[]) java.lang.reflect.Array.newInstance(klass,
+                        (int)list.getSize() + i);
+        System.arraycopy(initialElements, 0, ret, 0, i);
+        Iterator<? extends T> iterator = list.iterator();
+        Object o;
+        while((o = iterator.next()) != finished_.get_()){
+            ret[i++] = (T)o;
         }
         return ret;
     }


### PR DESCRIPTION
- use Iterator contract instead of `getRest()`
- use `System.arraycopy` where possible
- nullsafe
- whitespace fixes (untabify, trailing spaces)

Closes #232.

This commit is the result of squashing together all the commits in the [issue-232](https://github.com/lucaswerkmeister/ceylon.language/tree/issue-232) branch; I felt there was too much noise among those commits. If you want to merge that branch instead, feel free to!

Note also that due to a bug in my Eclipse’s JDT (Stack overflow when compiling or editing anything), this was written in Emacs. I hope that the indentation is okay (I tried to keep it consistent with the existing code, except where that was inconsistent itself – for example, a few lines were indented with tabs); I also added some `@SuppressWarnings("unchecked")` that might be unnecessary.
