### PR TITLE
Optimize Range.rest test for returning empty rest

### DIFF
--- a/src/ceylon/language/Range.ceylon
+++ b/src/ceylon/language/Range.ceylon
@@ -69,7 +69,7 @@ shared final class Range<Element>(first, last)
     "The rest of the range, without the start of the
      range."
     shared actual Element[] rest {
-        if (size==1) { return []; }
+        if (first==last) { return []; }
         Element n = next(first);
         return Range<Element>(n,last);
     }


### PR DESCRIPTION
If the `Range` has exactly one element, its `rest` is empty. Previously, the check for this was `size==1`. However, for big, non-`Enumerable` ranges (i. e. there is no mapping from `Element`s to `Integer`s), `size` is expensive because it has to iterate through all the `successor`s (or `predecessor`s). Instead, we now check if `first==last`, which is equivalent but faster.
