### PR TITLE
Add type argument to Correspondence.keys

### DIFF
--- a/runtime/ceylon/language/Array.java
+++ b/runtime/ceylon/language/Array.java
@@ -894,7 +894,7 @@ public final class Array<Element>
 
     @Override
     @Ignore
-    public Category<? super java.lang.Object> getKeys() {
+    public Category<? super ceylon.language.Integer> getKeys() {
         return $ceylon$language$Correspondence$this.getKeys();
     }
 

--- a/runtime/ceylon/language/ArraySequence.java
+++ b/runtime/ceylon/language/ArraySequence.java
@@ -432,7 +432,7 @@ public class ArraySequence<Element> implements Sequence<Element>, ReifiedType {
 
     @Override
     @Ignore
-    public Category<? super java.lang.Object> getKeys() {
+    public Category<? super ceylon.language.Integer> getKeys() {
         return $ceylon$language$Correspondence$this.getKeys();
     }
 

--- a/runtime/ceylon/language/String.java
+++ b/runtime/ceylon/language/String.java
@@ -364,12 +364,12 @@ public final class String
 
     @Override
     @Ignore
-    public Category<? super java.lang.Object> getKeys() {
+    public Category<? super ceylon.language.Integer> getKeys() {
         return $ceylon$language$Correspondence$this.getKeys();
     }
 
     @Ignore
-    public static Category<? super java.lang.Object> 
+    public static Category<? super ceylon.language.Integer> 
     getKeys(java.lang.String value) {
         // TODO We're still boxing here!
         return instance(value).getKeys();

--- a/src/ceylon/language/Correspondence.ceylon
+++ b/src/ceylon/language/Correspondence.ceylon
@@ -38,7 +38,7 @@ shared interface Correspondence<in Key, out Item>
     "The `Category` of all keys for which a value is 
      defined by this `Correspondence`."
     see (`function Correspondence.defines`)
-    shared default Category keys => Keys(this);
+    shared default Category<Key> keys => Keys(this);
     
     "Determines if this `Correspondence` defines a value
      for every one of the given keys."

--- a/src/ceylon/language/Keys.ceylon
+++ b/src/ceylon/language/Keys.ceylon
@@ -1,13 +1,7 @@
 class Keys<in Key, out Item>(Correspondence<Key,Item> correspondence)
-        // needs explicit type arg as workaround for https://github.com/ceylon/ceylon-spec/issues/918
-        satisfies Category<Object> 
+        satisfies Category<Key>
         given Key satisfies Object {
-    shared actual Boolean contains(Object key) {
-        if (is Key key) {
-            return correspondence.defines(key);
-        }
-        else {
-            return false;
-        }
+    shared actual Boolean contains(Key key) {
+        return correspondence.defines(key);
     }
 }


### PR DESCRIPTION
Changes `Correspondence.keys` from a bland `Category` to a `Category<Key>`.

Also requires test fixes in ceylon-compiler; will edit as soon as that PR is submitted.
EDIT: ceylon/ceylon-compiler#1650.
