### PR TITLE
Don’t evaluate the first element twice in sequential()

### DIFF
--- a/src/ceylon/language/impl/sequential.ceylon
+++ b/src/ceylon/language/impl/sequential.ceylon
@@ -9,28 +9,26 @@
 shared Element[] sequential<Element>({Element*} iterable) {
     if (is Element[] iterable) {
         return iterable;
-    } 
-    if (iterable.empty) {
-        return [];
     }
-    else {
+    value it = iterable.iterator();
+    if (!is Finished firstElement = it.next()) {
         object notempty satisfies {Element+} {
             shared actual Iterator<Element> iterator() {
-                value it = iterable.iterator();
                 object iterator satisfies Iterator<Element> {
                     variable value first = true;
                     shared actual Element|Finished next() {
-                        value next = it.next();
                         if (first) {
                             first = false;
-                            assert (!next is Finished);
+                            return firstElement;
                         }
-                        return next;
+                        return it.next();
                     }
                 }
                 return iterator;
             }
         }
         return ArraySequence(notempty);
+    } else {
+        return [];
     }
 }


### PR DESCRIPTION
`sequential()` would potentially evaluate the first element of the iterable twice: once when testing the emptiness, and once again when actually collecting the elements. Reuse it instead.

(Tested by the test fixed in 4dd19f1.)
