### PR TITLE
Improve firstIndexWhere() performance

### DIFF
--- a/src/ceylon/language/List.ceylon
+++ b/src/ceylon/language/List.ceylon
@@ -484,13 +484,16 @@ shared interface List<out Element>
             "The predicate function the indexed elements 
              must satisfy"
             Boolean selecting(Element&Object element)) {
+        value iter = iterator();
         variable value index = 0;
+        variable value elem = iter.next();
         while (index<size) {
-            if (exists element=getFromFirst(index), 
+            if (exists element=elem, !is Finished element,
                 selecting(element)) {
                 return index;
             }
             index++;
+            elem = iter.next();
         }
         return null;
     }


### PR DESCRIPTION
`firstIndexWhere()` used to address the elements by index using `getFromFirst()`. This is an O(n) operation for linked lists, making `firstIndexWhere()` as a whole an O(n²) operation for linked lists. That can easily be avoided by using an iterator instead.

Just to give you an idea: The performance of

``` ceylon
void run() {
    value max = 100_000;
    value list = LinkedList(1..max);
    value t1 = system.milliseconds;
    for (x in 1:10) {
        value i = list.firstIndexWhere(max.equals);
    }
    value t2 = system.milliseconds;
    print(t2-t1);
}
```

improved from 109613ms (almost 2 minutes) to 27ms (well under a second).

Also, I found this by VisualVM’ing `ceylon.formatter`… `LinkedList.getFromFirst` was **30%** of CPU time. With this change, the time of formatting [FormattingWriter.ceylon](https://github.com/lucaswerkmeister/ceylon.formatter/blob/21c0a414be3c48fe01f106488ef2fbd55eb7aa4c/source/ceylon/formatter/FormattingWriter.ceylon) 1000 times dropped from 51711502536ns to 33513870453ns (ratio 0.65). That’s _crazy_.
