### PR TITLE
Fix typo: last -> list

### DIFF
--- a/src/ceylon/language/List.ceylon
+++ b/src/ceylon/language/List.ceylon
@@ -290,7 +290,7 @@ shared interface List<out Element>
      
      - If `length==0`, the patched list has the given values 
        \"inserted\" into this list at the given index `from`.
-     - If the given `list` is empty, the patched last has 
+     - If the given `list` is empty, the patched list has 
        the measure of this list identified by `from:length` 
        \"deleted\".
      - If `from==size`, the patched list is formed by


### PR DESCRIPTION
@gavinking I think you missed my [comment](https://github.com/ceylon/ceylon.language/commit/a264b7a40070d60e3c783bb5d7701f2befaf82cc#commitcomment-6831220), so here’s a PR instead.
