### PR TITLE
Fix spelling mistakes

### DIFF
--- a/src/ceylon/language/AssertionError.ceylon
+++ b/src/ceylon/language/AssertionError.ceylon
@@ -1,4 +1,4 @@
-"An error that occurs due to an incorrectly writen program. 
+"An error that occurs due to an incorrectly written program. 
  An instance is thrown when an assertion fails, that is, 
  when a condition in an `assert` statement evaluates to 
  false at runtime."

--- a/src/ceylon/language/Obtainable.ceylon
+++ b/src/ceylon/language/Obtainable.ceylon
@@ -28,7 +28,7 @@ shared interface Obtainable {
     "Obtain this resource. Called before the body of a `try` 
      statement is executed.
      
-     If an exception is thown by `obtain()`, then `release()` 
+     If an exception is thrown by `obtain()`, then `release()` 
      will not be called."
     throws (`class AssertionError`, 
             "if an illegal state is detected")

--- a/src/ceylon/language/Ranged.ceylon
+++ b/src/ceylon/language/Ranged.ceylon
@@ -27,7 +27,7 @@
      print(\"hello world\"[-5..-1]); //prints \"\"
      print(\"hello world\"[11..11]); //prints \"\"
  
- The first index may be ommitted, implying that the subrange
+ The first index may be omitted, implying that the subrange
  extends forward from the smallest possible index (in this
  case `runtime.minIntegerValue-1`) to the given index.
  
@@ -39,7 +39,7 @@
  
      print(\"hello world\"[-5...]); //prints \"\"
  
- The last index may be ommitted, implying that the subrange 
+ The last index may be omitted, implying that the subrange 
  extends forward from the given index to the largest 
  possible index (in this case `runtime.maxIntegerValue+1`).
  

--- a/src/ceylon/language/Throwable.ceylon
+++ b/src/ceylon/language/Throwable.ceylon
@@ -31,7 +31,7 @@ import ceylon.language { printTrace=printStackTrace }
  The use of the exceptions facility to manage _expected 
  failures_, that is, failures that are usually handled by 
  the immediate caller of an operation, is discouraged. 
- Instead, the failure should be respresented as a return 
+ Instead, the failure should be represented as a return 
  value of the operation being called.
  
  For example, nonexistence of a file should not result in an 

--- a/src/ceylon/language/concatenate.ceylon
+++ b/src/ceylon/language/concatenate.ceylon
@@ -10,7 +10,7 @@
  
      concatenate(1..3, [0.0], {\"hello\", \"world\"})
  
- resuts in the sequence `[1, 2, 3, 0.0, \"hello\", \"world\"]`
+ results in the sequence `[1, 2, 3, 0.0, \"hello\", \"world\"]`
  which has the type `[Integer|Float|String*]`."
 see (`function expand`, 
      `function Iterable.chain`,

--- a/src/ceylon/language/meta/declaration/NestableDeclaration.ceylon
+++ b/src/ceylon/language/meta/declaration/NestableDeclaration.ceylon
@@ -1,6 +1,6 @@
 "A declaration which can be contained in a [[Package]] or in another [[NestableDeclaration]].
  
- Functions, values, classes, interfaes and aliases are such declarations."
+ Functions, values, classes, interfaces and aliases are such declarations."
 shared interface NestableDeclaration of FunctionOrValueDeclaration |
                                         ClassOrInterfaceDeclaration |
                                         SetterDeclaration |


### PR DESCRIPTION
Found with

``` bash
find -name '*.ceylon' -exec grep '^\(    \)*\( \|"\)[^ ]' {} + > tmp
```

to find text that's most likely documentation (starts with 4n + 1 spaces), and then

``` bash
hunspell tmp
```

to spellcheck the text. (Most of the unknown words were still not actual typos (references to classes and functions), but this is still better than just spellchecking the entire code, where there would be even more such false positives.)
