### PR TITLE
Added `reversed` attribute to Comparison

### DIFF
--- a/src/ceylon/language/Comparison.ceylon
+++ b/src/ceylon/language/Comparison.ceylon
@@ -3,13 +3,22 @@
 see (`interface Comparable`)
 by ("Gavin")
 shared abstract class Comparison(shared actual String string) 
-        of larger | smaller | equal {}
+        of larger | smaller | equal {
+    "The reversed value of this comparison."
+    shared formal Comparison reversed;
+}
 
 "The value is exactly equal to the given value."
-shared object equal extends Comparison("equal") {}
+shared object equal extends Comparison("equal") {
+    reversed => this;
+}
 
 "The value is smaller than the given value."
-shared object smaller extends Comparison("smaller") {}
+shared object smaller extends Comparison("smaller") {
+    reversed => larger;
+}
 
 "The value is larger than the given value."
-shared object larger extends Comparison("larger") {}
+shared object larger extends Comparison("larger") {
+    reversed => smaller;
+}


### PR DESCRIPTION
In Java, when we want to reverse a Comparison, we multiply by -1 the comparison.
In Ceylon we can't do that, that's why I believe that this attribute might be useful.

If you think this is useless, just let me know, I'll close this pull request.
