### PR TITLE
faster primitive narrowing conversions

### DIFF
--- a/runtime/com/redhat/ceylon/compiler/java/Util.java
+++ b/runtime/com/redhat/ceylon/compiler/java/Util.java
@@ -1598,15 +1598,15 @@ public class Util {
      *  @throws ceylon.language.OverflowException
      */
     public static int toInt(long value) {
-        if (value <= java.lang.Integer.MAX_VALUE
-                && value >= java.lang.Integer.MIN_VALUE) {
-            return (int)value;
+        int result = (int) value;
+        if (result != value) {
+            throw new OverflowException();
         }
-        throw new OverflowException();
+        return result;
     }
     
     /** 
-     * <p>Typecast a {@code long} to a {@code shot}, or throw if the {@code long} 
+     * <p>Typecast a {@code long} to a {@code short}, or throw if the {@code long}
      * cannot be safely converted.</p>
      *   
      * <p>We need to do this:</p>
@@ -1617,11 +1617,11 @@ public class Util {
      *  @throws ceylon.language.OverflowException
      */
     public static short toShort(long value) {
-        if (value <= java.lang.Short.MAX_VALUE
-                && value >= java.lang.Short.MIN_VALUE) {
-            return (short)value;
+        short result = (short) value;
+        if (result != value) {
+            throw new OverflowException();
         }
-        throw new OverflowException();
+        return result;
     }
     
     /** 
@@ -1637,11 +1637,11 @@ public class Util {
      *  @throws ceylon.language.OverflowException
      */
     public static byte toByte(long value) {
-        if (value <= java.lang.Byte.MAX_VALUE
-                && value >= java.lang.Byte.MIN_VALUE) {
-            return (byte)value;
+        byte result = (byte) value;
+        if (result != value) {
+            throw new OverflowException();
         }
-        throw new OverflowException();
+        return result;
     }
 
     /**


### PR DESCRIPTION
As discussed on IRC, this change can significantly improve performance for narrowing conversions required for native array access. In one test involving multiplication of two `long[]`s, overall execution time was reduced by 20%.

I'm not sure _why_ this change results in faster execution, and in fact, seemingly trivial or unrelated differences in the code that calls `toInt(...)` can dramatically affect the amount of improvement. But in my tests, there was always an improvement of at least a few percent.

I also tried:

``` java
    public static final long MAX_INT = Integer.MAX_VALUE;
    public static final long MIN_INT = Integer.MIN_VALUE;

    public static int toInt(long value) {
        if (value > MAX_INT || value < MIN_INT) {
            throw new OverflowException();
        }
        return (int)value;
    }
```

which resulting in no change at all from the original.
