### PR TITLE
reduce boxing in parseInteger

### DIFF
--- a/src/ceylon/language/parseInteger.ceylon
+++ b/src/ceylon/language/parseInteger.ceylon
@@ -35,22 +35,23 @@ shared Integer? parseInteger(
     
     assert (minRadix <= radix <= maxRadix); 
     
-    variable Integer index = 0;
+    Integer start;
     Integer max = runtime.minIntegerValue / radix;
     
     // Parse the sign
     Boolean negative;
-    if (exists char = string[index]) {
+    if (exists char = string.first) {
         if (char == '-') {
             negative = true;
-            index++;
+            start = 1;
         }
         else if (char == '+') {
             negative = false;
-            index++;
+            start = 1;
         }
         else {
             negative = false;
+            start = 0;
         }
     }
     else {
@@ -64,15 +65,10 @@ shared Integer? parseInteger(
     Integer length = string.size;
     variable Integer result = 0;
     variable Integer digitIndex = 0;
+    variable Integer index = start;
     while (index < length) {
-        Character ch;
-        if (exists char = string[index]) {
-            ch = char;
-        }
-        else {
-            return null;
-        }
-        
+        assert (exists ch = string.getFromFirst(index));
+
         if (index + 1 == length && 
                 radix == 10 && 
                 ch in "kMGTP") {


### PR DESCRIPTION
This is a pretty minor improvement, so feel free to close this PR or ask me to close it if it's not worth the review time.

It also serves as an example for #606. Arguably the assertion on `getFromFirst` is preferable as a failure indicates a programming error rather than invalid input.