### PR TITLE
Using the unicode name that actually is used in Ceylon for `Character.whitespace`

### DIFF
--- a/src/ceylon/language/Character.ceylon
+++ b/src/ceylon/language/Character.ceylon
@@ -76,7 +76,7 @@ shared final native class Character(Character character)
      - *FORM FEED*, `\\f` or `\\{#000C}`,
      - *CARRIAGE RETURN*, `\\r` or `\\{#000D}`,
      - *HORIZONTAL TABULATION*, `\\t` or `\\{#0009}`,
-     - *VERTICAL TABULATION*, `\\{#000B}`,
+     - *LINE TABULATION* (*VERTICAL TABULATION*), `\\{#000B}`,
      - *FILE SEPARATOR*, `\\{#001C}`,
      - *GROUP SEPARATOR*, `\\{#001D}`,
      - *RECORD SEPARATOR*, `\\{#001E}`,

--- a/src/ceylon/language/Character.ceylon
+++ b/src/ceylon/language/Character.ceylon
@@ -76,7 +76,7 @@ shared final native class Character(Character character)
      - *FORM FEED*, `\\f` or `\\{#000C}`,
      - *CARRIAGE RETURN*, `\\r` or `\\{#000D}`,
      - *HORIZONTAL TABULATION*, `\\t` or `\\{#0009}`,
-     - *LINE TABULATION* (*VERTICAL TABULATION*), `\\{#000B}`,
+     - *LINE TABULATION*, `\\{#000B}`,
      - *FILE SEPARATOR*, `\\{#001C}`,
      - *GROUP SEPARATOR*, `\\{#001D}`,
      - *RECORD SEPARATOR*, `\\{#001E}`,


### PR DESCRIPTION
The compiler won't accept `'\{VERTICAL TABULATION}'`, since its name is `\{LINE TABULATION}`.