### PR TITLE
Fix runtime issue; perform module lookup by ClassLoader as a fallback

### DIFF
--- a/runtime/com/redhat/ceylon/compiler/java/runtime/model/RuntimeModelLoader.java
+++ b/runtime/com/redhat/ceylon/compiler/java/runtime/model/RuntimeModelLoader.java
@@ -10,6 +10,7 @@ import org.jboss.modules.ModuleClassLoader;
 import com.redhat.ceylon.cmr.api.ArtifactResult;
 import com.redhat.ceylon.cmr.api.JDKUtils;
 import com.redhat.ceylon.common.runtime.CeylonModuleClassLoader;
+import com.redhat.ceylon.compiler.java.codegen.Decl;
 import com.redhat.ceylon.compiler.loader.LoaderJULLogger;
 import com.redhat.ceylon.compiler.loader.ModelResolutionException;
 import com.redhat.ceylon.compiler.loader.impl.reflect.CachedTOCJars;
@@ -169,10 +170,32 @@ public class RuntimeModelLoader extends ReflectionModelLoader {
             String jdkModuleName = JDKUtils.getJDKModuleNameForPackage(pkgName);
             if(jdkModuleName != null)
                 return findModule(jdkModuleName, JDKUtils.jdk.version);
-            return lookupModuleByPackageName(pkgName);
+            return lookupModuleByPackageNameAndClassLoader(pkgName, cl);
         }
     }
-    
+
+    protected Module lookupModuleByPackageNameAndClassLoader(
+            String packageName, ClassLoader cl) {
+        Module module = lookupModuleByPackageName(packageName);
+        if (module.equals(modules.getDefaultModule())) {
+            if (cl.equals(classLoaders.get(module))) {
+                return module;
+            }
+            // search for a better match based on ClassLoader
+            for (Map.Entry<Module, ClassLoader> entry : classLoaders.entrySet()) {
+                // skip modules we're not loading things from (per lookupModuleByPackageName)
+                if(!Decl.equalModules(module,getLanguageModule())
+                        && !isModuleInClassPath(module)) {
+                    continue;
+                }
+                if (cl.equals(entry.getValue())) {
+                    return entry.getKey();
+                }
+            }
+        }
+        return module;
+    }
+
     @Override
     protected String cacheKeyByModule(Module module, String name) {
         if(module == null)


### PR DESCRIPTION
In flat classpath deployments (war), it's possible to have failed `is` tests due to the inability to identify a module for a class when package lookup fails. (This does not happen w/JBoss Modules, since in that case, lookup is already by ClassLoader.)

Affected classes include dynamic proxies created at runtime, with packages like `com.sun.proxy`. I imagine this may also occur for excluded dependencies (`ceylon war --exclude-module ...`), and possibly in other cases if `pom.xml` restrictions are lifted.

There may be better options - my approach was to go for minimal change & impact. And, I'm not sure how this affects compile time checks; my goal was to address runtime issues.

Example that triggers `is` test problem:

```ceylon
import java.lang.reflect {
    Proxy, InvocationHandler, Method
}

import java.lang {
    ObjectArray
}

import ceylon.interop.java {
    createJavaObjectArray,
    javaClass
}

shared void run() {
    value proxy = Proxy.newProxyInstance(
        javaClass<Foo>().classLoader,
        createJavaObjectArray { javaClass<Foo>() },
        object satisfies InvocationHandler {
            shared actual Object invoke(
                Object? \iobject, Method? method,
                ObjectArray<Object>? objectArray) => nothing;
        }
    );
    print(isType<Foo>(proxy));
}

shared Boolean isType<T>(Anything obj) {
    return (obj is T);
}
```
