### PR TITLE
make javaa test run method shared

### DIFF
--- a/test-java/javaa/run.ceylon
+++ b/test-java/javaa/run.ceylon
@@ -1,4 +1,4 @@
-void run(){
+shared void run(){
     print("Running Java-specific tests");
     bugJvm1290();
     print("Java-specific tests OK");


### PR DESCRIPTION
This helps `ant test.java` run a bit longer.