### PR TITLE
Collections optimizations

### DIFF
--- a/src/ceylon/language/Collection.ceylon
+++ b/src/ceylon/language/Collection.ceylon
@@ -54,7 +54,19 @@ shared interface Collection<out Element>
             return false;
         }
     }
-    
+
+    "Determines if this stream has fewer elements than the
+     given [[length]]. This operation is equivalent to
+     [[size]] < [[length]]."
+    shared actual default
+    Boolean shorterThan(Integer length) => size<length;
+
+    "Determines if this stream has more elements than the
+     given [[length]]. This operation is equivalent to
+     [[size]] > [[length]]."
+    shared actual default
+    Boolean longerThan(Integer length) => size>length;
+
     "A string of form `\"{ x, y, z }\"` where `x`, `y`, and 
      `z` are the `string` representations of the elements of 
      this collection, as produced by the iterator of the 

--- a/src/ceylon/language/Iterable.ceylon
+++ b/src/ceylon/language/Iterable.ceylon
@@ -1016,7 +1016,9 @@ shared interface Iterable<out Element, out Absent=Null>
      results in the stream `{ 123, 456 }`."
     shared default 
     {Element&Object*} coalesced 
-            => { for (e in this) if (exists e) e };
+            => if (is {Object*} result = this)
+               then result
+               else { for (e in this) if (exists e) e };
     
     "A stream containing all [[entries|Entry]] of form 
      `index->element` where `element` is an element of this

--- a/src/ceylon/language/Iterable.ceylon
+++ b/src/ceylon/language/Iterable.ceylon
@@ -1002,7 +1002,9 @@ shared interface Iterable<out Element, out Absent=Null>
     defaultNullElements<Default>(
             "A default value that replaces `null` elements."
             Default defaultValue)
-            => { for (elem in this) elem else defaultValue };
+            => if (is {Object*} result = this)
+               then result
+               else { for (elem in this) elem else defaultValue };
     
     "The non-null elements of this stream, in the order in
      which they occur in this stream. For null elements of 

--- a/src/ceylon/language/List.ceylon
+++ b/src/ceylon/language/List.ceylon
@@ -232,12 +232,6 @@ shared interface List<out Element>
         return hash;
     }
     
-    shared actual default
-    Boolean shorterThan(Integer length) => size<length;
-    
-    shared actual default 
-    Boolean longerThan(Integer length) => size>length;
-    
     "A list containing the elements of this list repeated 
      the [[given number of times|times]], or an empty list
      if `times<=0`. For every `index` of a repeated `list`:

--- a/src/ceylon/language/Map.ceylon
+++ b/src/ceylon/language/Map.ceylon
@@ -257,7 +257,9 @@ shared interface Map<out Key,out Item>
      non-null."
     shared default
     Map<Key,Item&Object> coalescedMap 
-            => object
+        => if (is Map<Key,Object> result = this)
+           then result
+           else object
             extends Object()
             satisfies Map<Key,Item&Object> {
         


### PR DESCRIPTION
This PR includes two items:

1. Avoid wrapping collections when accessing `coalesced` if they cannot hold nulls to begin with. This should help especially in cases where the would-be-wrapped type has optimized methods that the wrapper doesn't take advantage of.

1. Override `shorterThan` and `longerThan` in `Collection` to use `size` (in `Iterable`, an iteration is performed to determine the size.) The assumption being that `Collection`s should have optimized size properties. Otherwise, I guess we'll need to add these overrides to the various subtypes.

One observation is that with so many default methods, it's very easy to leave things like `size` and `contains` unoptimized when implementing collections. I'm wondering if these should be declared `formal` in `Collection` to force satisfying types to deal with them?

** I just noticed, `defaultNullElements` could use the same optimization as `coalesced`. So if this PR makes sense, I can add that too.