### PR TITLE
Fix Enumerable docs

### DIFF
--- a/src/ceylon/language/Enumerable.ceylon
+++ b/src/ceylon/language/Enumerable.ceylon
@@ -41,7 +41,7 @@
  
  - `x.neighbour(count)==x`,
  - `x.offset(y) >= 0` for any instance `y` of `X`, and 
- - `x.predecessor.offset(x) == count`.
+ - `x.predecessor.offset(x) == count - 1`.
  
  A range of values of an enumerable type may be specified 
  using:


### PR DESCRIPTION
`Enumerable` docs say "`x.predecessor.offset(x) == count`" must be true where `x` is an instance of a recursive enumerable type with a finite list of enumerated instances of size `count`. It should say "`x.predecessor.offset(x) == count - 1`."