### PR TITLE
Fix documentation of Array.OfSize size parameter

### DIFF
--- a/src/ceylon/language/Array.ceylon
+++ b/src/ceylon/language/Array.ceylon
@@ -23,7 +23,7 @@ shared final native class Array<Element>
     see (`value runtime.maxArraySize`)
     shared native new OfSize(
             "The size of the resulting array. If the size is 
-             non-positive, an empty array will be created."
+             negative, an exception will be thrown."
             Integer size, 
             "The element value with which to populate the array.
              All elements of the resulting array will have the 


### PR DESCRIPTION
Fix documentation of `Array.OfSize` `size` parameter to match the `throws` annotation and the actual implementation.

Mistake introduced by @gavinking in d7dbbd8.