### PR TITLE
Simplify printAll

### DIFF
--- a/src/ceylon/language/print.ceylon
+++ b/src/ceylon/language/print.ceylon
@@ -19,15 +19,7 @@ by ("Gavin")
 see (`function process.write`)
 shared void printAll({Anything*} values,
         "A character sequence to use to separate the values"
-        String separator=", ") {
-    if (exists first = values.first) {
-        process.write(stringify(first));
-        for (val in values.rest) {
-            process.write(separator);
-            process.write(stringify(val));
-        }
-    }
-    process.write(operatingSystem.newline);
-}
+        String separator=", ")
+        => print(separator.join(values.map(stringify)));
 
 String stringify(Anything val) => val?.string else "<null>";


### PR DESCRIPTION
Previously, `printAll` evaluated `first` and then `rest`; in the default implementation of `rest`, this would cause the first element to be evaluated twice. Using `String.join` avoids this problem.

Could someone else test this for me? I can’t run the `ceylon.language` tests currently (due to an unrelated module system problem).

CC @gavinking @jvasileff