### PR TITLE
Main API : use ceylon-module-resolver classloader instead of system classloader (discussion)

### DIFF
--- a/runtime/com/redhat/ceylon/compiler/java/runtime/Main.java
+++ b/runtime/com/redhat/ceylon/compiler/java/runtime/Main.java
@@ -752,7 +752,7 @@ public class Main {
     public void run(String module, String version, String runClass, String... arguments){
         setup(module, version);
         try {
-            Class<?> klass = ClassLoader.getSystemClassLoader().loadClass(runClass);
+            Class<?> klass = Configuration.class.getClassLoader().loadClass(runClass);
             invokeMain(klass, arguments);
         } catch (ClassNotFoundException | NoSuchMethodException | SecurityException 
                  | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
@@ -874,7 +874,7 @@ public class Main {
         // skip JDK modules which are already in the metamodel
         if(module.type == ClassPath.Type.JDK)
             return;
-        Metamodel.loadModule(name, version, module, ClassLoader.getSystemClassLoader());
+        Metamodel.loadModule(name, version, module, Configuration.class.getClassLoader());
         // also register its dependencies
         for(ClassPath.Dependency dep : module.dependencies)
             registerInMetamodel(dep.name(), dep.version(), dep.optional);


### PR DESCRIPTION
This is related to
https://groups.google.com/forum/#!topic/ceylon-users/UWx7CGIMwuw

I've created this pull request to have a place to discuss this topic. I'm not sure at all that it must be merged
Basically the idea is to use the classloader of a class belonging to ceylon-module-resolver instead of the system classloader when discovering the classes via the Main API (to init the metamodel).

Because in my case (a Gradle+Ceylon experiment) the classes were loaded by Gradle and did not end up in the system classloader.
Using the classloader of a class of ceylon-module-resolver at least I know that I'm going to use the classloader that was used to load the classes of the Ceylon. It could be the system classloader, or not, but it should always work.
Just scrap this pull request if this does not make any sense.