### PR TITLE
Fix module import syntax in test-java

### DIFF
--- a/test-java/javaa/module.ceylon
+++ b/test-java/javaa/module.ceylon
@@ -1,5 +1,5 @@
 "Runtime tests that require java modules"
 module javaa "1" {
-    import "org.apache.camel.camel-core" "2.9.4";
+    import "org.apache.camel:camel-core" "2.9.4";
     import org.slf4j.api "1.6.1";
 }


### PR DESCRIPTION
This has caused the tests to fail for me for a while now (@davidfestal explained it to me [three weeks ago](https://gitter.im/ceylon/user?at=5526d900ccd8b83865e9e35b), and @jvasileff again [one week ago](https://gitter.im/ceylon/user?at=552e9ede08c7a53a4a1d6eea)). Is there any particular reason why it wasn’t fixed yet? Is it somehow working for others?