### PR TITLE
make ceylon.language::sum fast

### DIFF
--- a/src/ceylon/language/sum.ceylon
+++ b/src/ceylon/language/sum.ceylon
@@ -4,10 +4,33 @@ see (`function product`)
 shared Value sum<Value>({Value+} values) 
         given Value satisfies Summable<Value> {
     value it = values.iterator();
-    assert (!is Finished first = it.next());
-    variable value sum = first;
-    while (!is Finished val = it.next()) {
-        sum += val;
+    value first = it.next();
+    if (is Integer first) {
+        // unbox; don't infer type Value&Integer
+        variable Integer sum = first;
+        while (is Integer val = it.next()) {
+            Integer unboxed = val;
+            sum += unboxed;
+        }
+        assert (is Value result = sum);
+        return result;
     }
-    return sum;
+    else if (is Float first) {
+        // unbox; don't infer type Value&Float
+        variable Float sum = first;
+        while (is Float val = it.next()) {
+            Float unboxed = val;
+            sum += unboxed;
+        }
+        assert (is Value result = sum);
+        return result;
+    }
+    else {
+        assert (!is Finished first);
+        variable value sum = first;
+        while (!is Finished val = it.next()) {
+            sum += val;
+        }
+        return sum;
+    }
 }


### PR DESCRIPTION
This implementation avoids using a boxed type for the `sum` accumulator variable when summing `Integer`s and `Float`s.

If you want to merge this, I can also make the change for `product`.

**Benchmark Script**
```ceylon
shared void sumTest() {
    for (size in [1, 2, 4, 8, 32, 128, 256, 1024]) {
        value ints = (1..size).collect(identity);
        value floats = (1..size).collect(Integer.float);
        value repeat = 2^27 / size;

        benchmark {
            scale = repeat * size  / 10;
            warmupIter = 3;
            benchIter = 5;
            ["lang::sum(ints); size=``size``:", () => (0:repeat).each((_) => sum(ints))],
            ["math::sum(ints); size=``size``:", () => (0:repeat).each((_) => mathSum(ints))],
            ["optimized(ints); size=``size``:", () => (0:repeat).each((_) => sumNew4(ints))]
        };

        benchmark {
            scale = repeat*size  / 10;
            warmupIter = 3;
            benchIter = 5;
            ["lang::sum(floats); size=``size``:", () => (0:repeat).each((_) => sum(floats))],
            ["math::sum(floats); size=``size``:", () => (0:repeat).each((_) => mathSumF(floats))],
            ["optimized(floats); size=``size``:", () => (0:repeat).each((_) => sumNew4(floats))]
        };
    }
}
```

**Integer Results**
```
Summary min/max/avg/rstddev/pct
math::sum(ints); size=1: 116/124/118/3% (100%)
optimized(ints); size=1: 120/127/123/2% (103%)
lang::sum(ints); size=1: 139/141/140/0% (119%)

Summary min/max/avg/rstddev/pct
optimized(ints); size=2: 65/69/66/1% (100%)
lang::sum(ints); size=2: 69/71/70/1% (105%)
math::sum(ints); size=2: 73/76/74/1% (112%)

Summary min/max/avg/rstddev/pct
optimized(ints); size=4: 47/47/47/0% (100%)
math::sum(ints); size=4: 52/53/52/1% (109%)
lang::sum(ints); size=4: 57/59/58/1% (121%)

Summary min/max/avg/rstddev/pct
optimized(ints); size=8: 37/38/37/1% (100%)
math::sum(ints); size=8: 41/42/41/0% (111%)
lang::sum(ints); size=8: 53/55/54/1% (143%)

Summary min/max/avg/rstddev/pct
optimized(ints); size=32: 32/32/32/0% (100%)
math::sum(ints); size=32: 33/37/34/4% (103%)
lang::sum(ints); size=32: 55/56/56/0% (172%)

Summary min/max/avg/rstddev/pct
optimized(ints); size=128: 29/33/30/5% (100%)
math::sum(ints); size=128: 30/31/30/0% (105%)
lang::sum(ints); size=128: 50/52/51/1% (173%)

Summary min/max/avg/rstddev/pct
optimized(ints); size=256: 29/33/31/4% (99%)
math::sum(ints); size=256: 30/35/32/6% (102%)
lang::sum(ints); size=256: 51/57/55/4% (173%)

Summary min/max/avg/rstddev/pct
optimized(ints); size=1024: 29/30/29/2% (100%)
math::sum(ints); size=1024: 29/30/30/0% (102%)
lang::sum(ints); size=1024: 51/52/51/1% (175%)
```

**Float Results**
```
Summary min/max/avg/rstddev/pct
lang::sum(floats); size=1: 92/97/95/1% (100%)
optimized(floats); size=1: 126/130/128/1% (135%)
math::sum(floats); size=1: 149/154/152/1% (160%)

Summary min/max/avg/rstddev/pct
optimized(floats); size=2: 68/70/69/1% (100%)
lang::sum(floats); size=2: 68/72/70/2% (100%)
math::sum(floats); size=2: 92/94/93/0% (134%)

Summary min/max/avg/rstddev/pct
optimized(floats); size=4: 50/52/51/2% (100%)
lang::sum(floats); size=4: 59/63/61/3% (117%)
math::sum(floats); size=4: 63/66/65/1% (127%)

Summary min/max/avg/rstddev/pct
optimized(floats); size=8: 39/40/40/0% (100%)
math::sum(floats); size=8: 48/50/49/1% (122%)
lang::sum(floats); size=8: 55/57/56/1% (138%)

Summary min/max/avg/rstddev/pct
optimized(floats); size=32: 32/33/33/1% (100%)
math::sum(floats); size=32: 37/37/37/0% (113%)
lang::sum(floats); size=32: 57/59/58/1% (174%)

Summary min/max/avg/rstddev/pct
optimized(floats); size=128: 29/30/29/1% (100%)
math::sum(floats); size=128: 33/34/34/1% (113%)
lang::sum(floats); size=128: 53/55/54/1% (184%)

Summary min/max/avg/rstddev/pct
optimized(floats); size=256: 28/30/29/2% (100%)
math::sum(floats); size=256: 32/33/33/1% (115%)
lang::sum(floats); size=256: 53/54/53/0% (188%)

Summary min/max/avg/rstddev/pct
optimized(floats); size=1024: 28/29/28/1% (100%)
math::sum(floats); size=1024: 32/34/32/2% (115%)
lang::sum(floats); size=1024: 53/54/54/0% (190%)
```
