### PR TITLE
support creation of non-infinte streams by loop()

### DIFF
--- a/src/ceylon/language/loop.ceylon
+++ b/src/ceylon/language/loop.ceylon
@@ -1,19 +1,20 @@
-"Produces the [[stream|Iterable]] that results from repeated 
- application of the given [[function|next]] to the given 
- [[first]] element of the stream. The stream is infinite.
- 
+"Produces the [[stream|Iterable]] that results from repeated
+ application of the given [[function|next]] to the given
+ [[first]] element of the stream. The stream may be infinite.
+
  For example:
- 
+
      loop(0)(2.plus).takeWhile(10.largerThan)
- 
+
  produces the stream `{ 0, 2, 4, 6, 8 }`."
 shared {Element+} loop<Element>(
         "The first element of the resulting stream."
         Element first)(
         "The function that produces the next element of the
-         stream, given the current element."
-        Element next(Element element))
-    => let (start = first) 
+         stream, given the current element. The function may
+         return [[finished]] to indicate the end of the stream."
+        Element|Finished next(Element element))
+    => let (start = first)
     object satisfies {Element+} {
         first => start;
         empty => false;
@@ -21,15 +22,19 @@ shared {Element+} loop<Element>(
             "stream is infinite"
             assert(false);
         }
-        function nextElement(Element element) 
+        function nextElement(Element element)
                 => next(element);
         iterator()
                 => object satisfies Iterator<Element> {
-            variable Element current = start;
-            shared actual Element next() {
-                Element result = current;
-                current = nextElement(current);
-                return result;
+            variable Element|Finished current = start;
+            shared actual Element|Finished next() {
+                if (is Element result = current) {
+                    current = nextElement(result);
+                    return result;
+                }
+                else {
+                    return finished;
+                }
             }
         };
     };


### PR DESCRIPTION
This change allows the function provided to `loop` to return `finished` to indicate the end of the stream.

It was inspired by the following use case:

```ceylon
    shared
    DartSimpleIdentifier identifierForCapture(FunctionOrValueModel declaration) {
        value declarations = loop<DeclarationModel>(declaration)((d)
            =>  if (is DeclarationModel result = d.container)
                then result
                else finished);

        return
        DartSimpleIdentifier {
            declarations
                .collect(getName)
                .reversed
                .interpose("$")
                .fold("$capture$")(plus);
        };
    }
```