### PR TITLE
Float.integer: show float value in OverflowException

### DIFF
--- a/runtime/ceylon/language/Character.java
+++ b/runtime/ceylon/language/Character.java
@@ -321,7 +321,7 @@ public final class Character
 
     public static int codepoint(long value) {
         if (value>0x10FFFF || value<0) {
-            throw new OverflowException(value + " is not a 32-bit integer");
+            throw new OverflowException(value + " is not a possible Unicode code point");
         }
         return Util.toInt(value);
     }

--- a/runtime/ceylon/language/Float.java
+++ b/runtime/ceylon/language/Float.java
@@ -412,7 +412,7 @@ public final class Float
             return (long)value;
         }
         else {
-            throw new OverflowException("Numeric overflow converting Float " + value + " to Integer.");
+            throw new OverflowException(value + " cannot be coerced to a 64 bit integer");
         }
     }
     

--- a/runtime/ceylon/language/Float.java
+++ b/runtime/ceylon/language/Float.java
@@ -412,7 +412,7 @@ public final class Float
             return (long)value;
         }
         else {
-        	throw new OverflowException();
+            throw new OverflowException("Numeric overflow converting Float " + value + " to Integer.");
         }
     }
     

--- a/runtime/ceylon/language/Integer.java
+++ b/runtime/ceylon/language/Integer.java
@@ -368,7 +368,7 @@ public final class Integer
         long neighbour = value+offset;
         //Overflow iff both arguments have the opposite sign of the result
         if (((value^neighbour) & (offset^neighbour)) < 0) {
-            throw new OverflowException("neighbour overflow");
+            throw new OverflowException(value + " has no neighbour with offset " + offset);
         }
         return neighbour;
     }
@@ -384,7 +384,8 @@ public final class Integer
         //Overflow iff the arguments have different signs and
         //the sign of the result is different than the sign of x
         if (((value^other) & (value^offset)) < 0) {
-            throw new OverflowException("offset overflow");
+            throw new OverflowException(
+                    "offset from " + value + " to " + other + " cannot be represented as a 64 bit integer.");
         }
         return offset;
     }

--- a/runtime/ceylon/language/Integer.java
+++ b/runtime/ceylon/language/Integer.java
@@ -421,7 +421,7 @@ public final class Integer
     public static double getFloat(long value) {
         if (value >= 9007199254740992L
                 || value <= -9007199254740992L) {
-            throw new OverflowException();
+            throw new OverflowException(value + " cannot be coerced into a 64 bit floating point value");
         }
         else {
         	return (double) value;

--- a/runtime/com/redhat/ceylon/compiler/java/Util.java
+++ b/runtime/com/redhat/ceylon/compiler/java/Util.java
@@ -1708,7 +1708,7 @@ public class Util {
     public static int toInt(long value) {
         int result = (int) value;
         if (result != value) {
-            throw new OverflowException();
+            throw new OverflowException(value + " cannot be safely converted into a 32-bit integer");
         }
         return result;
     }
@@ -1727,7 +1727,7 @@ public class Util {
     public static short toShort(long value) {
         short result = (short) value;
         if (result != value) {
-            throw new OverflowException();
+            throw new OverflowException(value + " cannot be safely converted into a 16 bit integer");
         }
         return result;
     }
@@ -1747,7 +1747,7 @@ public class Util {
     public static byte toByte(long value) {
         byte result = (byte) value;
         if (result != value) {
-            throw new OverflowException();
+            throw new OverflowException(value + " cannot be safely converted into a 8-bit integer");
         }
         return result;
     }

--- a/test/characters.ceylon
+++ b/test/characters.ceylon
@@ -52,14 +52,29 @@ shared void characters() {
     check('B'.notSmallerThan('A'), "Character.notSmallerThan");
     check('A'.neighbour(2)=='C', "Character.neighbour 1");
     check('Z'.neighbour(-2)=='X', "Character.neighbour 2");
+    // check that those don't throw OverflowExceptions:
+    value zero = (0).character;
+    check(zero == '\{#0000}', "zero character");
+    value max = (#10ffff).character;
+    check (max == '\{#10ffff}');
     try {
         fail("Character out of range: ``(2147483650).character`` ");
     } catch (OverflowException ex) {
-        check(ex.message == "2147483650 is not a 32-bit integer", "Character ouf of range message #1");
+        check(ex.message == "2147483650 is not a possible Unicode code point", "Character ouf of range message #1");
     }
     try {
         fail("Character out of range: ``(-2147483650).character``");
     } catch (OverflowException ex) {
-        check(ex.message == "-2147483650 is not a 32-bit integer", "Character ouf of range message #2");
+        check(ex.message == "-2147483650 is not a possible Unicode code point", "Character ouf of range message #2");
+    }
+    try {
+        fail("Character out of range: ``(-1).character`` ");
+    } catch (OverflowException ex) {
+        check(ex.message == "-1 is not a possible Unicode code point", "Character ouf of range message #3");
+    }
+    try {
+        fail("Character out of range: ``(#110000).character``");
+    } catch (OverflowException ex) {
+        check(ex.message == "1114112 is not a possible Unicode code point", "Character ouf of range message #4");
     }
 }


### PR DESCRIPTION
When converting a Float value outside of the Integer range (i.e. to large in either positive or negative direction, an infinity, or NaN) to Integer, you currently get an OverflowException (with the default message "Numeric Overflow"), without any indication which number caused the Overflow.

(In the case which trapped me, I had a NaN, but took quite some debugging time to figure this out.)

This commits adds a slightly more user friendly message to the Exception.

Should we add similar messages to other places where OverflowException is thrown?