### PR TITLE
Issue #759: Add attribute Integer.nearestFloat.

### DIFF
--- a/runtime-js/Integer/nearestFloat.js
+++ b/runtime-js/Integer/nearestFloat.js
@@ -1,0 +1,1 @@
+return Float(this.valueOf());

--- a/runtime-js/numbers.js
+++ b/runtime-js/numbers.js
@@ -216,6 +216,8 @@ atr$(JSNum$proto, 'character', function(){
   }
   return Character(this.valueOf());
 },undefined,function(){return{an:function(){return[shared(),actual()]},mod:$CCMM$,$cont:Integer,d:['$','Integer','$at','character']};});
+atr$(JSNum$proto, 'nearestFloat', function(){ return Float(this.valueOf()); },
+  undefined,function(){return{an:function(){return[shared(),actual()]},mod:$CCMM$,$cont:Integer,d:['$','Integer','$at','nearestFloat']};});
 atr$(JSNum$proto, 'successor', function(){ return this+1; },
   undefined,function(){return{an:function(){return[shared(),actual()]},mod:$CCMM$,$cont:Ordinal,d:['$','Ordinal','$at','successor']};});
 atr$(JSNum$proto, 'predecessor', function(){ return this-1; },

--- a/runtime-js/numbers.js
+++ b/runtime-js/numbers.js
@@ -216,8 +216,6 @@ atr$(JSNum$proto, 'character', function(){
   }
   return Character(this.valueOf());
 },undefined,function(){return{an:function(){return[shared(),actual()]},mod:$CCMM$,$cont:Integer,d:['$','Integer','$at','character']};});
-atr$(JSNum$proto, 'nearestFloat', function(){ return Float(this.valueOf()); },
-  undefined,function(){return{an:function(){return[shared(),actual()]},mod:$CCMM$,$cont:Integer,d:['$','Integer','$at','nearestFloat']};});
 atr$(JSNum$proto, 'successor', function(){ return this+1; },
   undefined,function(){return{an:function(){return[shared(),actual()]},mod:$CCMM$,$cont:Ordinal,d:['$','Ordinal','$at','successor']};});
 atr$(JSNum$proto, 'predecessor', function(){ return this-1; },

--- a/runtime/ceylon/language/Integer.java
+++ b/runtime/ceylon/language/Integer.java
@@ -428,6 +428,15 @@ public final class Integer
         }
     }
 
+    public double getNearestFloat() {
+        return (double) value;
+    }
+
+    @Ignore
+    public static double getNearestFloat(long value) {
+        return (double) value;
+    }
+
     public byte getByte() {
         return getByte(value);
     }

--- a/src/ceylon/language/Integer.ceylon
+++ b/src/ceylon/language/Integer.ceylon
@@ -146,7 +146,17 @@ shared native final class Integer(Integer integer)
         "if the number cannot be represented as a `Float`
          without loss of precision")
     shared native Float float;
-    
+
+    "The nearest [[Float]] to this number. For
+     Integers in magnitude less than 2^53, this is always
+     a Float with the exact same mathematical value (and the
+     same value as [[float]]), for larger ones on the JVM the
+     Floats are less dense than the Integers so there can be some
+     loss of precision.
+
+     This method never throws an OverflowException."
+    shared native Float nearestFloat;
+
     shared actual native Integer predecessor;
     shared actual native Integer successor;
     shared actual native Integer neighbour(Integer offset);

--- a/test/numbers.ceylon
+++ b/test/numbers.ceylon
@@ -181,6 +181,20 @@ shared void numbers() {
     check((-1.1).integer==-1, "(-1.1).integer is `` (-1.1).integer `` instead of -1");
     check(2.float==2.0, "integer float");
     check((-3).float==-3.0, "negative integer float");
+    check(2.nearestFloat==2.0, "small integer nearestFloat");
+    check((-3).nearestFloat==-3.0, "small negative integer nearestFloat");
+    
+    
+    
+    try {
+       fail("Should have thrown Overflow Exception: ``922337203685477632.float``");
+    } catch(OverflowException ex) {
+        check(ex.message == "922337203685477632 cannot be coerced into a 64 bit floating point value");
+    }
+    
+    check(922337203685477632.nearestFloat == 9.2233720368547763E17, "large nearest float 1");
+    check((-922337203685477632).nearestFloat == -9.2233720368547763E17, "large negative nearest float");
+    check(922337203685477635.nearestFloat == 9.2233720368547763E17, "large nearest float 2");
     
     check(1.plus { other=2; }.equals { that=3; }, "natural named args");
 


### PR DESCRIPTION
~~I implemented it in Ceylon, using the arithmetic promotion property of the `+` operator.
A Java implementation would be a simple cast, but then I would have to figure out how to get the JavaScript implementation to do the same.~~

~~*(I'll also add some tests, please wait for the next commit before merging.)*~~

**Update**
As one can't implement this in Ceylon, I implemented this both in Java and in Javascript. Someone please have a look at the JavaScript implementation, I have no idea what I'm doing there (that was mainly copy+paste from other similar-looking lines there).