### PR TITLE
Issue #758: let only "small" Integers be equal to Floats.

### DIFF
--- a/runtime-js/numbers.js
+++ b/runtime-js/numbers.js
@@ -190,7 +190,14 @@ atr$(JSNum$proto, 'negative', function(){
 atr$(JSNum$proto, 'positive', function(){
   return nflt$(this) ? this > 0.0 : this.valueOf() > 0;
 },undefined,function(){return{$t:{t:$_Boolean},an:function(){return[shared(),actual()]},mod:$CCMM$,$cont:$_Number,d:['$','Number','$at','positive']};});
-JSNum$proto.equals = function(other) { return (typeof(other)==='number' || other.constructor===Number) && other==this.valueOf(); }
+$TWO$FIFTY$THREE = 0x20000000000000; 
+JSNum$proto.equals = function(other) {
+	return (typeof(other)==='number' || other.constructor===Number) &&
+	other==this.valueOf() &&
+	((nflt$(this) == nflt$(other)) // both are floats or both are integers
+			 || (-$TWO$FIFTY$THREE < this.valueOf() &&
+					 this.valueOf() < $TWO$FIFTY$THREE)); // small floats and small integers are also allowed to be same 
+}
 $addnm$('equals',$_Object.$$.prototype.equals);
 JSNum$proto.compare = function(other) {
     var value = this.valueOf();

--- a/runtime/ceylon/language/Float.java
+++ b/runtime/ceylon/language/Float.java
@@ -455,7 +455,8 @@ public final class Float
     @Ignore
     public static boolean equals(double value, java.lang.Object that) {
         if (that instanceof Integer) {
-            return value == ((Integer)that).value;
+            long intValue = ((Integer) that).value;
+            return value == intValue && -Integer.TWO_FIFTY_THREE < intValue && intValue < Integer.TWO_FIFTY_THREE;
         } 
         else if (that instanceof Float) {
             return value == ((Float)that).value;

--- a/runtime/ceylon/language/Integer.java
+++ b/runtime/ceylon/language/Integer.java
@@ -29,6 +29,8 @@ public final class Integer
                Exponentiable<Integer,Integer>, 
                ReifiedType {
 
+    static final long TWO_FIFTY_THREE = 1L << 53;
+
     @Ignore
     public final static TypeDescriptor $TypeDescriptor$ = TypeDescriptor.klass(Integer.class);
 
@@ -433,8 +435,7 @@ public final class Integer
 
     @Ignore
     public static double getFloat(long value) {
-        if (value >= 9007199254740992L
-                || value <= -9007199254740992L) {
+        if (value <= -TWO_FIFTY_THREE || TWO_FIFTY_THREE <= value) {
             throw new OverflowException(value + " cannot be coerced into a 64 bit floating point value");
         }
         else {
@@ -527,7 +528,7 @@ public final class Integer
             return value == ((Integer)that).value;
         }
         else if (that instanceof Float) {
-            return value == ((Float)that).value;
+            return value == ((Float) that).value && -TWO_FIFTY_THREE < value && value < TWO_FIFTY_THREE;
         }
         else {
             return false;
@@ -540,7 +541,7 @@ public final class Integer
             return value == ((Integer)that).value;
         }
         else if (that instanceof Float) {
-            return value == ((Float)that).value;
+            return value == ((Float) that).value && -TWO_FIFTY_THREE < value && value < TWO_FIFTY_THREE;
         }
         else {
             return false;

--- a/runtime/ceylon/language/Integer.java
+++ b/runtime/ceylon/language/Integer.java
@@ -524,15 +524,7 @@ public final class Integer
 
     @Override
     public boolean equals(@Name("that") java.lang.Object that) {
-        if (that instanceof Integer) {
-            return value == ((Integer)that).value;
-        }
-        else if (that instanceof Float) {
-            return value == ((Float) that).value && -TWO_FIFTY_THREE < value && value < TWO_FIFTY_THREE;
-        }
-        else {
-            return false;
-        }
+        return equals(value, that);
     }
 
     @Ignore

--- a/src/ceylon/language/Float.ceylon
+++ b/src/ceylon/language/Float.ceylon
@@ -121,9 +121,9 @@ shared native final class Float(Float float)
      - the given object is an [[Integer]],
      - this value is neither [[undefined]], nor [[infinite]],
      - the [[fractionalPart]] of this value equals `0.0`, 
-       and
      - the [[integer]] part of this value equals the given 
-       integer."
+       integer, and
+     - the given integer is between -2<sup>53</sup> and 2<sup>53</sup> (exclusive)."
     shared actual native Boolean equals(Object that);
     
     shared actual native Integer hash;

--- a/src/ceylon/language/Integer.ceylon
+++ b/src/ceylon/language/Integer.ceylon
@@ -13,8 +13,10 @@
  exception raised).
  
  An integer is considered equal to its [[float]] 
- representation. That is, for every integer `int`, the 
- expression `int.float==int` evaluates to `true`.
+ representation, if that exists. That is, for every
+ integer `int`, either `int.float` throws an
+ OverflowException or the expression `int.float==int`
+ evaluates to `true`.
  
  An integer is represented as a sequence of bits. Not all of 
  the bits in the representation may be addressed by the 
@@ -83,7 +85,8 @@ shared native final class Integer(Integer integer)
      - the [[fractional part|Float.fractionalPart]] of its 
        value equals `0.0`, and
      - the [[integer part|Float.integer]] part of its value 
-       equals this integer."
+       equals this integer, and
+     - this integer is between -2<sup>53</sup> and 2<sup>53</sup> (exclusive)."
     shared actual native Boolean equals(Object that);
     
     shared actual native Integer hash;

--- a/test/numbers.ceylon
+++ b/test/numbers.ceylon
@@ -1,5 +1,6 @@
 @test
 shared void numbers() {
+    Object ob(Object x) { return x; }
     check(1==1, "natural equals");
     check(1!=2, "natural not equals");
     check(+1==+1, "integer equals");
@@ -13,6 +14,12 @@ shared void numbers() {
     check(+1==1, "natural equals integer");
     check(1.0==1, "natural equals float");
     check(1.0==+1, "integer equals float");
+    check(9007199254740991 == 9007199254740991.0, "large integer equals float");
+    check(9007199254740993 != 9007199254740993.0, "large integer doesn't equal float");
+    check(922337203685477632 != 9.2233720368547763E17, "even larger integer doesn't equal float");
+    check(9007199254740991.0 == 9007199254740991, "large float equals integer");
+    check(9007199254740993.0 != 9007199254740993, "large float doesn't equal integer");
+    check(9.2233720368547763E17 != 922337203685477632, "even larger float doesn't equal integer");
     check(1<2, "natural comparison");
     check(-1<+2, "integer comparison");
     check(-0.5<0.0, "float comparison");


### PR DESCRIPTION
As discussed in #758, now Integers with magnitude 2^53 or larger will not be considered equal to their float counterparts anymore on the JVM. (These are the same numbers for which `Integer.float` throws an OverflowException.)

An explanation would be that each floating point number corresponds to an interval, and for those big numbers the intervals contain multiple integers.

I also updated the documentation ... I'm not sure if the JavaScript implementation needs to be adapted too?